### PR TITLE
nix: fix server setup and improve deploy

### DIFF
--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: "[Server] Push release to the server"
         run: |
+          echo "${{ secrets.VM_ARGS }}" > $(pwd)/server/config/vm.args
           echo "${{ secrets.APP_SETTINGS }}" > $(pwd)/.env
 
       - name: "[Server] Push release to the server"

--- a/.rsyncignore
+++ b/.rsyncignore
@@ -6,9 +6,11 @@
 .vs
 .vscode
 .*.~undo-tree~
+.env_*
 client
 _build
 result
+erl_crash.*
 LICENSE
 README.org
 deploy.sh

--- a/README.org
+++ b/README.org
@@ -7,7 +7,8 @@
 
 * About
 
-This is Lyceum --- an MMO game with the server written in Erlang and the client written in Zig superchanged with [[https://github.com/raysan5/raylib][raylib]].
+This is Lyceum --- an MMO game with the server written in [[https://www.erlang.org/][Erlang]] and the client
+written in [[https://ziglang.org/][Zig]] (superchanged with [[https://github.com/raysan5/raylib][raylib]] and [[https://github.com/dont-rely-on-nulls/zerl][Zerl]]).
 
 * How to run
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,14 +38,14 @@ rsync \
     . \
     $DEPLOY_USER@$DEPLOY_HOST:~/$PROJECT_NAME
 
-# Build a docker image with the release
-nix build .#dockerImage
+# Build the server locally
+nix build .#server
 
-# Also copy the built docker image
+# And copy the build to the Host
 nix copy \
   --no-check-sigs \
-  --to ssh-ng://$DEPLOY_HOST ".#dockerImage"
+  --to ssh-ng://$DEPLOY_HOST ".#server"
 
 echo "[DEPLOY] Running entrypoint script..."
 PROJECT_NAME=$PROJECT_NAME \
-    ssh $DEPLOY_USER@$DEPLOY_HOST "cd ~/$PROJECT_NAME && ./deploy_entrypoint.sh"
+    ssh $DEPLOY_USER@$DEPLOY_HOST "cd ~/$PROJECT_NAME && just start"

--- a/deploy_entrypoint.sh
+++ b/deploy_entrypoint.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Luckily, we've already cached the build from CI
-sudo nix build .#dockerImage
-sudo docker load < result
-sudo docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   app:
     container_name: lyceum
-    image: lyceum:latest
+    image: lyceum_server:latest
     network_mode: "host"
     restart: always
     env_file:

--- a/server/config/sys.config
+++ b/server/config/sys.config
@@ -1,0 +1,12 @@
+[
+ {kernel, [
+  {logger, [
+    {handler, structured, logger_std_h,
+       #{formatter => {flatlog, #{
+         map_depth => 3,
+         term_depth => 50
+        }}}
+    }
+  ]}
+ ]}
+].

--- a/server/config/vm.args
+++ b/server/config/vm.args
@@ -1,0 +1,5 @@
+## Name of the node
+-sname lyceum_server
+
+## Cookie for distributed Erlang
+-setcookie lyceum

--- a/server/database/migrate_down.sh
+++ b/server/database/migrate_down.sh
@@ -6,7 +6,11 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 
 set -euxo pipefail
 
-PG_URL=${PG_URL:-"postgresql://admin:admin@127.0.0.1:5432/mmo"}
+PG_HOST=${PGHOST:-localhost}
+PG_USER=${PGUSER:-admin}
+PG_PASSWORD=${PGPASSWORD:-admin}
+PG_DATABASE=${PGDATABASE:-mmo}
+PG_URL=${PG_URL:-"postgresql://$PG_USER:$PG_PASSWORD@$PG_HOST:5432/$PG_DATABASE"}
 
 echo "Setting PG_URL=${PG_URL}"
 

--- a/server/database/migrate_input.sh
+++ b/server/database/migrate_input.sh
@@ -6,7 +6,11 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 
 set -euxo pipefail
 
-PG_URL=${PG_URL:-"postgresql://admin:admin@127.0.0.1:5432/mmo"}
+PG_HOST=${PGHOST:-localhost}
+PG_USER=${PGUSER:-admin}
+PG_PASSWORD=${PGPASSWORD:-admin}
+PG_DATABASE=${PGDATABASE:-mmo}
+PG_URL=${PG_URL:-"postgresql://$PG_USER:$PG_PASSWORD@$PG_HOST:5432/$PG_DATABASE"}
 
 echo "Setting PG_URL=${PG_URL}"
 

--- a/server/database/migrate_up.sh
+++ b/server/database/migrate_up.sh
@@ -6,7 +6,11 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 
 set -euxo pipefail
 
-PG_URL=${PG_URL:-"postgresql://admin:admin@127.0.0.1:5432/mmo"}
+PG_HOST=${PGHOST:-localhost}
+PG_USER=${PGUSER:-admin}
+PG_PASSWORD=${PGPASSWORD:-admin}
+PG_DATABASE=${PGDATABASE:-mmo}
+PG_URL=${PG_URL:-"postgresql://$PG_USER:$PG_PASSWORD@$PG_HOST:5432/$PG_DATABASE"}
 
 echo "Setting PG_URL=${PG_URL}"
 

--- a/server/rebar.config
+++ b/server/rebar.config
@@ -5,7 +5,7 @@
 ]}.
 
 {shell, [
-  % {config, "config/sys.config"},
+    {sys_config, "config/sys.config"},
     {apps, [server_app]}
 ]}.
 
@@ -14,9 +14,11 @@
     {sname, 'lyceum_server'}
 ]}.
 
-{relx, [{release, {server, "0.0.1"},
+{relx, [{release, {lyceum_server, "0.0.1"},
          [server_app]},
 
+        {sys_config, "config/sys.config"},
+        {vm_args, "config/vm.args"},
         {dev_mode, true},
         {include_erts, false},
 


### PR DESCRIPTION
1. We need some `vm.args` to properly set the remote erlang node. The value used there is not the same one used in prod tho, CI will override it.
2. Improved Nix quite a bit to the point where we can either test the server with pure nix or use a nix-based docker image. Example:
```
nix build .#server
./result/bin/lyceum_server foreground
```
3. Modify CI deployment as well
4. Modify db scripts so the justfile works inside the vm as well