### PR TITLE
feat: add initial unit tests for server

### DIFF
--- a/server/test/registry_tests.erl
+++ b/server/test/registry_tests.erl
@@ -1,0 +1,52 @@
+-module(registry_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+check_user_success_test() ->
+    meck:new(epgsql),
+    meck:new(database_utils),
+    
+    meck:expect(epgsql, equery, fun(_Conn, _Query, _Params) -> 
+        {ok, ["username", "e_mail", "password"], [
+            [<<"user1">>, <<"user1@email.com">>, <<"1234">>]
+        ]}
+    end),
+    
+    meck:expect(database_utils, columns_and_rows, fun(Arg) ->
+        io:format("MOCK columns_and_rows called with: ~p~n", [Arg]),
+        [#{username => <<"user1">>, e_mail => <<"user1@email.com">>, password => <<"1234">>}]
+    end),
+    
+    UserMap = #{username => <<"user1">>, password => <<"1234">>},
+    Result = registry:check_user(UserMap, fake_conn),
+    
+    ?assertEqual({ok, <<"user1@email.com">>}, Result),
+    
+    meck:unload(epgsql),
+    meck:unload(database_utils).
+
+
+insert_user_success_test() ->
+    meck:new(epgsql),
+    meck:new(postgres_m),
+
+    meck:expect(epgsql, equery, fun(_Conn, _Query, _Params) ->
+        {ok, 1}  
+    end),
+
+    meck:expect(postgres_m, '>>=', fun({{ok, Count}, insert}, Fun) ->
+        Fun(Count)
+    end),
+
+    UserMap = #{
+        username => <<"user1">>,
+        email => <<"user1@email.com">>,
+        password => <<"1234">>
+    },
+
+    Result = registry:insert_user(UserMap, fake_conn),
+    ?assertEqual(ok, Result),
+
+    meck:unload(epgsql),
+    meck:unload(postgres_m).
+    

--- a/server/test/server_sup_tests.erl
+++ b/server/test/server_sup_tests.erl
@@ -1,0 +1,82 @@
+-module(server_sup_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+start_link_test() ->
+    meck:new(database),
+    meck:new(migraterl),
+    meck:new(map_generator),
+    
+    meck:expect(database, connect, fun() -> {ok, fake_connection} end),
+    meck:expect(migraterl, migrate, fun(_,_,_) -> {ok, []} end),
+    meck:expect(map_generator, create_map, fun(_,_,_) -> ok end),
+    
+    meck:new(world_sup, [non_strict]),
+    meck:new(dispatcher_sup, [non_strict]),
+    meck:new(player_sup, [non_strict]),
+    
+    meck:expect(world_sup, start_link, fun() -> {ok, self()} end),
+    meck:expect(dispatcher_sup, start_link, fun() -> {ok, self()} end),
+    meck:expect(player_sup, start_link, fun() -> {ok, self()} end),
+
+    {ok, Pid} = server_sup:start_link(),
+    ?assert(is_pid(Pid)),
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(Pid, whereis(server_sup)),
+
+    meck:unload(world_sup),
+    meck:unload(dispatcher_sup),
+    meck:unload(player_sup),
+    meck:unload(database),
+    meck:unload(migraterl),
+    meck:unload(map_generator).
+
+init_test() ->
+    {ok, {SupFlags, ChildSpecs}} = server_sup:init([]),
+
+    ExpectedFlags = #{
+        strategy => one_for_one,
+        intensity => 12,
+        period => 3600
+    },
+    ?assertEqual(ExpectedFlags, SupFlags),
+
+    ExpectedSpecs = [
+        #{
+            id => dispatcher_sup,
+            start => {dispatcher_sup, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => supervisor,
+            modules => [dispatcher_sup]
+        },
+        #{
+            id => player_sup,
+            start => {player_sup, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => supervisor,
+            modules => [player_sup]
+        },
+        #{
+            id => world_sup,
+            start => {world_sup, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => supervisor,
+            modules => [world_sup]
+        }
+    ],
+
+    ActualSpecsSorted = lists:sort(fun(A, B) ->
+        maps:get(id, A) =< maps:get(id, B)
+    end, ChildSpecs),
+
+    ExpectedSpecsSorted = lists:sort(fun(A, B) ->
+        maps:get(id, A) =< maps:get(id, B)
+    end, ExpectedSpecs),
+
+    ?assertEqual(ExpectedSpecsSorted, ActualSpecsSorted).
+    
+    
+    

--- a/server/test/server_tests.erl
+++ b/server/test/server_tests.erl
@@ -1,0 +1,18 @@
+-module(server_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+start_test() ->
+    meck:new(server_sup),
+    meck:expect(server_sup, start_link, fun() -> {ok, mocked_pid} end),
+
+    {ok, Result} = server:start(normal, []),
+
+    ?assertEqual(mocked_pid, Result),
+    ?assert(meck:called(server_sup, start_link, [])),
+
+    meck:unload(server_sup).
+    
+
+stop_test() ->
+    ?assertEqual(ok, server:stop(any_value)).

--- a/server/test/world_sup_tests.erl
+++ b/server/test/world_sup_tests.erl
@@ -1,0 +1,35 @@
+-module(world_sup_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("include/server_state.hrl").
+
+start_link_test() ->
+    meck:new(world, [non_strict]),
+    meck:expect(world, start_link, fun() -> {ok, self()} end),
+
+    {ok, Pid} = world_sup:start_link(),
+
+    ?assert(is_pid(Pid)),
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(Pid, whereis(world_sup)),
+ 
+    meck:unload(world).
+
+init_test() ->
+    {ok, {SupFlags, [WorldWorker]}} = world_sup:init([]),
+
+    ExpectedFlags = #{
+        strategy => one_for_one,
+        intensity => 12,
+        period => 3600
+    },
+
+    ?assertEqual(ExpectedFlags, SupFlags),
+    ?assertEqual(world, maps:get(id, WorldWorker)),
+    ?assertEqual({world, start_link, []}, maps:get(start, WorldWorker)),
+    ?assertEqual(permanent, maps:get(restart, WorldWorker)),
+    ?assertEqual(brutal_kill, maps:get(shutdown, WorldWorker)),
+    ?assertEqual(worker, maps:get(type, WorldWorker)),
+    ?assertEqual([world], maps:get(modules, WorldWorker)).
+    
+     

--- a/server/test/world_tests.erl
+++ b/server/test/world_tests.erl
@@ -1,0 +1,55 @@
+-module(world_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("include/server_state.hrl").
+
+start_link_test() -> 
+    meck:new(database),
+    meck:new(migraterl),
+    meck:new(map_generator),
+    
+    meck:expect(database, connect, fun() -> {ok, fake_connection} end),
+    
+    meck:expect(migraterl, migrate, fun(_,_,_) -> {ok, []} end),
+    
+    meck:expect(map_generator, create_map, fun(_,_,_) -> ok end),
+    
+    {ok, WorldPid} = world:start_link(),
+    
+    ?assert(is_pid(WorldPid)),
+    ?assert(is_process_alive(WorldPid)),
+    ?assertEqual(WorldPid, global:whereis_name(world)),
+    ?assert(meck:called(database, connect, [])),
+    ?assert(meck:num_calls(migraterl, migrate, 3) >= 1),
+    ?assert(meck:num_calls(map_generator, create_map, 3) >= 1),
+    
+    global:unregister_name(world),
+
+    meck:unload(database),
+    meck:unload(migraterl),
+    meck:unload(map_generator).
+
+stop_test() ->
+    ?assertEqual(ok, server:stop(any_value)).
+
+init_test() ->
+    meck:new(database),
+    meck:new(migraterl),
+    meck:new(map_generator),
+
+    meck:expect(database, connect, fun() -> {ok, fake_connection} end),
+    meck:expect(migraterl, migrate, fun(_,_,_) -> {ok, []} end),
+    meck:expect(map_generator, create_map, fun(_,_,_) -> ok end),
+
+    {ok, State} = world:init([]),
+
+    ?assertMatch(#server_state{}, State),
+    ?assertEqual(fake_connection, State#server_state.connection),
+    ?assertEqual(self(), State#server_state.pid),
+    ?assert(meck:called(database, connect, [])),
+    ?assert(meck:num_calls(migraterl, migrate, 3) >= 1),
+    ?assert(meck:num_calls(map_generator, create_map, 3) >= 1),
+
+    meck:unload(database),
+    meck:unload(migraterl),
+    meck:unload(map_generator).


### PR DESCRIPTION
Adding initial unit tests. This is a simple start, as our goal is to achieve minimal code coverage to ensure safety during the future refactoring of this server into a distributed Erlang application.