### PR TITLE
#87 REFACTOR Finish player fsm and rename cache app

### DIFF
--- a/server/apps/auth/src/auth.app.src
+++ b/server/apps/auth/src/auth.app.src
@@ -10,7 +10,7 @@
         mnesia,
         epgsql,
         erlandono,
-        storage_mnesia
+        cache
     ]},
     {env, []},
     {modules, []},

--- a/server/apps/auth/src/simple_auth.erl
+++ b/server/apps/auth/src/simple_auth.erl
@@ -103,7 +103,7 @@ handle_call(_Request, _From, State) ->
              {noreply, auth_state(), timeout()} |
              {stop, term(), auth_state()}.
 handle_cast({logout, UserId}, State) ->
-    gen_server:cast(storage_mnesia, {logout, UserId}),
+    gen_server:cast(cache, {logout, UserId}),
     {noreply, State};
 handle_cast(Msg, State) ->
     logger:error("[~p] CAST: ~p~n", [?SERVER, Msg]),
@@ -217,7 +217,7 @@ start_new_worker(Cache) ->
     do([error_m
         || Request = {login, Cache},
            % TODO improve this
-           {ok, Data} = gen_server:call(storage_mnesia, Request),
+           {ok, Data} = gen_server:call(cache, Request),
            logger:info("[~p] USER: ~p~n", [?SERVER, Data]),
            case player_sup:start(Data) of
                {ok, Pid} ->

--- a/server/apps/cache/src/cache.app.src
+++ b/server/apps/cache/src/cache.app.src
@@ -1,8 +1,8 @@
-{application, storage_mnesia, [
+{application, cache, [
     {description, "An OTP application"},
     {vsn, {git, short}},
     {registered, []},
-    {mod, {storage_mnesia_app, []}},
+    {mod, {cache_app, []}},
     {applications, [
         kernel,
         stdlib,

--- a/server/apps/cache/src/cache.erl
+++ b/server/apps/cache/src/cache.erl
@@ -1,4 +1,4 @@
--module(storage_mnesia).
+-module(cache).
 -behaviour(gen_server).
 
 %% API

--- a/server/apps/cache/src/cache_app.erl
+++ b/server/apps/cache/src/cache_app.erl
@@ -3,7 +3,7 @@
 %% @end
 %%%-------------------------------------------------------------------
 
--module(storage_mnesia_app).
+-module(cache_app).
 
 -behaviour(application).
 
@@ -11,7 +11,7 @@
 
 start(_StartType, _StartArgs) ->
     logger:info("[~p] Starting Application...~n", [?MODULE]),
-    storage_mnesia_sup:start_link().
+    cache_sup:start_link().
 
 stop(_State) ->
     ok.

--- a/server/apps/cache/src/cache_sup.erl
+++ b/server/apps/cache/src/cache_sup.erl
@@ -2,8 +2,7 @@
 %% @doc storage_mnesia top level supervisor.
 %% @end
 %%%-------------------------------------------------------------------
-
--module(storage_mnesia_sup).
+-module(cache_sup).
 
 -behaviour(supervisor).
 
@@ -22,14 +21,14 @@ init([]) ->
           intensity => 10,
           period => 600},
 
-    StorageMNESIA =
-        #{id => storage_mnesia,
-          start => {storage_mnesia, start_link, []},
+    CacheMNESIA =
+        #{id => cache,
+          start => {cache, start_link, []},
           restart => permanent,
           shutdown => 600,
           type => worker,
-          modules => [storage_mnesia]},
+          modules => [cache]},
 
-    {ok, {SupFlags, [StorageMNESIA]}}.
+    {ok, {SupFlags, [CacheMNESIA]}}.
 
 %% internal functions

--- a/server/apps/cache/test/cache_SUITE.erl
+++ b/server/apps/cache/test/cache_SUITE.erl
@@ -1,4 +1,4 @@
--module(storage_mnesia_SUITE).
+-module(cache_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -37,7 +37,7 @@ init_per_testcase(TestCase, Config) ->
     meck:new(database),
     meck:expect(database, connect_as_mnesia, fun() -> {ok, fake_connection} end),
 
-    {ok, Pid} = storage_mnesia:start_link(),
+    {ok, Pid} = cache:start_link(),
     ct:pal("[~p] Gen Server started at ~p", [TestCase, Pid]),
 
     %% Create test data
@@ -47,7 +47,7 @@ init_per_testcase(TestCase, Config) ->
                       email = "player@email.com",
                       client_pid = self()},
 
-    gen_server:cast(storage_mnesia, {upsert_record, TestPlayer}),
+    gen_server:cast(cache, {upsert_record, TestPlayer}),
     timer:sleep(100), %% Allow cast to complete
 
     [{server_pid, Pid}, {test_player_01, TestPlayer} | Config].
@@ -80,14 +80,14 @@ test_get_by_id_success(Config) ->
     Email = TestCache#player_cache.email,
 
     %% Test get by ID
-    {ok, C} = gen_server:call(storage_mnesia, {get_by_id, PlayerId}),
+    {ok, C} = gen_server:call(cache, {get_by_id, PlayerId}),
 
     ?assertEqual(PlayerId, C#player_cache.player_id),
     ?assertEqual(Username, C#player_cache.username),
     ?assertEqual(Email, C#player_cache.email).
 
 test_get_by_id_failure(_Config) ->
-    {error, _} = gen_server:call(storage_mnesia, {get_by_id, "nonexistent"}).
+    {error, _} = gen_server:call(cache, {get_by_id, "nonexistent"}).
 
 %% Cache Operations
 test_login_success(Config) ->
@@ -99,7 +99,7 @@ test_login_success(Config) ->
     Request1 = {login, NewPlayer},
 
     %% Test if a new player is properly cached
-    {ok, C1} = gen_server:call(storage_mnesia, Request1),
+    {ok, C1} = gen_server:call(cache, Request1),
 
     ?assertEqual(NewPlayer#player_cache.player_id, C1#player_cache.player_id),
     ?assertEqual(NewPlayer#player_cache.username, C1#player_cache.username),
@@ -108,7 +108,7 @@ test_login_success(Config) ->
     %% Now the same for a player already logged in
     TestCache = ?config(test_player_01, Config),
     Request2 = {login, TestCache},
-    {ok, C2} = gen_server:call(storage_mnesia, Request2),
+    {ok, C2} = gen_server:call(cache, Request2),
 
     ?assertEqual(TestCache#player_cache.player_id, C2#player_cache.player_id),
     ?assertEqual(TestCache#player_cache.username, C2#player_cache.username),
@@ -123,12 +123,12 @@ test_upsert_record_success(_Config) ->
     Request1 = {upsert_record, NewPlayer},
 
     %% Test if a new player is properly cached
-    ok = gen_server:cast(storage_mnesia, Request1),
+    ok = gen_server:cast(cache, Request1),
     %% Allow cast to complete
     timer:sleep(200),
 
     Request2 = {get_by_id, NewPlayer#player_cache.player_id},
-    {ok, C1} = gen_server:call(storage_mnesia, Request2),
+    {ok, C1} = gen_server:call(cache, Request2),
 
     ?assertEqual(NewPlayer#player_cache.player_id, C1#player_cache.player_id),
     ?assertEqual(NewPlayer#player_cache.username, C1#player_cache.username),
@@ -137,12 +137,12 @@ test_upsert_record_success(_Config) ->
 test_logout_success(Config) ->
     TestPlayer = ?config(test_player_01, Config),
     Request1 = {logout, TestPlayer#player_cache.player_id},
-    ok = gen_server:cast(storage_mnesia, Request1),
+    ok = gen_server:cast(cache, Request1),
     %% Allow cast to complete
     timer:sleep(200),
 
     Request2 = {get_by_id, TestPlayer#player_cache.player_id},
-    {error, _} = gen_server:call(storage_mnesia, Request2).
+    {error, _} = gen_server:call(cache, Request2).
 
 %%--------------------------------------------------------------------
 %% Helper Functions

--- a/server/apps/player/src/player.erl
+++ b/server/apps/player/src/player.erl
@@ -1,180 +1,185 @@
-%%%-------------------------------------------------------------------
-%% @doc Player Server, each user is its own process.
+%%-------------------------------------------------------------------
+%% @doc
+%% A Player's Finite State Machine, each user has its own FSM that
+%% triggers changes into the World (and other players).
+%%
+%% States: logged_in, in_game, logged_out
 %% @end
 %%%-------------------------------------------------------------------
 -module(player).
 
--behaviour(gen_server).
+-behaviour(gen_statem).
 
 %% API
 -export([start_link/1]).
-%% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
-         code_change/3]).
+%% gen_statem callbacks
+-export([callback_mode/0, init/1, terminate/3, code_change/4]).
+%% State functions
+-export([logged_in/3, in_game/3]).
 
 -include("player_state.hrl").
+-include("player_fsm_state.hrl").
 
 -compile({parse_transform, do}).
-
--dialyzer({nowarn_function,
-           [exit_map/1, logout/1, joining_map/2, update/2, harvest_resource/2]}).
 
 %%%===================================================================
 %%% API
 %%%===================================================================
-
 %%--------------------------------------------------------------------
 %% @doc
-%% Starts a player's server
+%% Starts a player's FSM
 %% @end
 %%--------------------------------------------------------------------
 -spec start_link(Cache) -> Result
     when Cache :: player_cache(),
-         Result :: gen_server:start_ret().
+         Result :: gen_statem:start_ret().
 start_link(Cache) ->
-    logger:debug("GEN_SERVER ARGS ~p~n", [Cache]),
+    logger:debug("GEN_STATEM ARGS ~p~n", [Cache]),
     {ok, Conn} = database:connect(),
     PlayerId = Cache#player_cache.player_id,
     State = to_state(Conn, Cache),
-    logger:debug("[~p] GEN_SERVER NAME = ~p~nGEN_SERVER STATE = ~p~n",
+    logger:debug("[~p] GEN_STATEM NAME = ~p~nGEN_STATEM STATE = ~p~n",
                  [?MODULE, PlayerId, State]),
-    gen_server:start_link({global, PlayerId}, ?MODULE, State, []).
+    gen_statem:start_link({global, PlayerId}, ?MODULE, State, []).
 
 %%%===================================================================
-%%% gen_server callbacks
+%%% gen_statem callbacks
 %%%===================================================================
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Define callback mode
+%% https://www.erlang.org/doc/apps/stdlib/gen_statem.html#t:callback_mode/0
+%% @end
+%%--------------------------------------------------------------------
+callback_mode() ->
+    state_functions.
 
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% Initializes the server
-%%
-%% @spec init(Args) -> {ok, State} |
-%%                     {ok, State, Timeout} |
-%%                     ignore |
-%%                     {stop, Reason}
+%% Initializes the state machine
 %% @end
 %%--------------------------------------------------------------------
--spec init(player_state()) -> {ok, player_state()}.
+-spec init(State) -> Return
+    when State :: player_state(),
+         Return :: gen_statem:init_result(player_fsm_state()).
 init(State) ->
-    {ok, State}.
+    {ok, logged_in, State}.
 
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% Handling call messages
+%% State function for when player is logged in, but hasn't selected a
+%% character nor has joined any map.
 %% @end
 %%--------------------------------------------------------------------
--spec handle_call(term(), gen_server:from(), player_state()) -> Return
-    when Return ::
-             {reply, term(), player_state()} |
-             {reply, term(), player_state(), timeout()} |
-             {noreply, player_state()} |
-             {noreply, player_state(), timeout()} |
-             {stop, term(), term(), player_state()} |
-             {stop, term(), player_state()}.
-handle_call(_Request, _From, State) ->
-    Reply = ok,
-    {reply, Reply, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Handling cast messages
-%%
-%% @spec handle_cast(Msg, State) -> {noreply, State} |
-%%                                  {noreply, State, Timeout} |
-%%                                  {stop, Reason, State}
-%% @end
-%%--------------------------------------------------------------------
--spec handle_cast(term(), player_state()) -> Return
-    when Return ::
-             {noreply, player_state()} |
-             {noreply, player_state(), timeout()} |
-             {stop, term(), player_state()}.
-handle_cast(_Msg, State) ->
-    {noreply, State}.
-
-%%--------------------------------------------------------------------
-%% @private
-%% @doc
-%% Handling all non call/cast messages
-%%
-%% @spec handle_info(Info, State) -> {noreply, State} |
-%%                                   {noreply, State, Timeout} |
-%%                                   {stop, Reason, State}
-%% @end
-%%--------------------------------------------------------------------
--spec handle_info(term(), player_state()) -> Return
-    when Return ::
-             {noreply, player_state()} | {noreply, player_state()} | {stop, term(), player_state()}.
-handle_info({list_characters, Request}, State) ->
+-spec logged_in(EventType, term(), State) -> Return
+    when EventType :: gen_statem:event_type(),
+         State :: player_state(),
+         Return :: gen_statem:event_handler_result(atom()).
+logged_in(info, {list_characters, Request}, State) ->
     list_characters(State, Request),
-    {noreply, State};
-handle_info({joining_map,
-             #{username := Username,
-               email := Email,
-               name := Name} =
-                 Request},
-            OldState) ->
-    ok = joining_map(OldState, Request),
-    Data =
-        #player_data{email = Email,
-                     username = Username,
-                     character_name = Name},
-    NewState = OldState#player_state{data = Data},
-    {noreply, NewState};
-handle_info({update_character, Request}, State) ->
+    {keep_state, State};
+logged_in(info,
+          {joining_map,
+           #{username := Username,
+             email := Email,
+             name := Name} =
+               Request},
+          State) ->
+    case joining_map(State, Request) of
+        ok ->
+            Data =
+                #player_data{email = Email,
+                             username = Username,
+                             character_name = Name},
+            NewState = State#player_state{data = Data},
+            {next_state, in_game, NewState};
+        {error, _} ->
+            {keep_state, State}
+    end;
+logged_in(info, {update_character, Request}, State) ->
     update(State, Request),
-    {noreply, State};
-handle_info({harvest_resource, Request}, State) ->
-    harvest_resource(State, Request),
-    {noreply, State};
-handle_info(exit_map, State) ->
-    exit_map(State),
-    {noreply, State};
-handle_info(logout, State) ->
+    {keep_state, State};
+logged_in(info, logout, State) ->
     logout(State),
-    {noreply, State};
-handle_info({_, {login, _}}, State) ->
-    State#player_state.client_pid ! {error, "User already logged in"},
-    {noreply, State};
-handle_info(Info, State) ->
-    logger:warning("[~p] HANDLE_INFO: ~p~n", [?MODULE, Info]),
-    {noreply, State}.
+    {stop, normal, State};
+logged_in(EventType, Event, State) ->
+    handle_common_events(EventType, Event, State, logged_in).
 
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% This function is called by a gen_server when it is about to
-%% terminate. It should be the opposite of Module:init/1 and do any
-%% necessary cleaning up. When it returns, the gen_server terminates
-%% with Reason. The return value is ignored.
-%%
-%% @spec terminate(Reason, State) -> void()
+%% State function for when player is ready to play the game.
 %% @end
 %%--------------------------------------------------------------------
--spec terminate(term(), player_state()) -> ok.
-terminate(Reason, _State) ->
-    logger:info("[~p] Termination: ~p~n", [?MODULE, Reason]),
+-spec in_game(EventType, term(), State) -> Return
+    when EventType :: gen_statem:event_type(),
+         State :: player_state(),
+         Return :: gen_statem:event_handler_result(atom()).
+in_game(info, {update_character, Request}, State) ->
+    update(State, Request),
+    {keep_state, State};
+in_game(info, {harvest_resource, Request}, State) ->
+    harvest_resource(State, Request),
+    {keep_state, State};
+in_game(info, exit_map, State) ->
+    case exit_map(State) of
+        ok ->
+            {next_state, logged_in, State};
+        {error, _} ->
+            {stop, {shutdown, exit_map_failed}, State}
+    end;
+in_game(info, {list_characters, Request}, State) ->
+    list_characters(State, Request),
+    {keep_state, State};
+in_game(EventType, Event, State) ->
+    handle_common_events(EventType, Event, State, in_game).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This is called by a gen_statem when it is about to terminate.
+%% @end
+%%--------------------------------------------------------------------
+-spec terminate(term(), atom(), State) -> Return
+    when State :: player_state(),
+         Return :: ok.
+terminate(Reason, StateName, _State) ->
+    logger:info("[~p] Termination in state ~p: ~p~n", [?MODULE, StateName, Reason]),
     ok.
 
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
 %% Convert process state when code is changed
-%%
-%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
 %% @end
 %%--------------------------------------------------------------------
--spec code_change(term(), player_state(), term()) -> Return
-    when Return :: {ok, player_state()} | {error, term()}.
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+-spec code_change(term(), atom(), State, term()) -> Return
+    when State :: player_state(),
+         Return :: {ok, atom(), State}.
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handle events common to all states
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_common_events(EventType, term(), State, atom()) -> Return
+    when EventType :: gen_statem:event_type(),
+         State :: player_state(),
+         Return :: gen_statem:event_handler_result(atom()).
+handle_common_events(EventType, Info, State, StateName) ->
+    logger:warning("[~p] UNHANDLED EVENT ~p IN STATE ~p: ~p~n",
+                   [?MODULE, EventType, StateName, Info]),
+    {keep_state, State}.
+
 -spec to_state(Conn, Cache) -> State
     when Conn :: epgsql:connection(),
          Cache :: player_cache(),
@@ -190,33 +195,46 @@ to_state(Conn, Cache) ->
                   player_id = PlayerId,
                   data = Data}.
 
--spec list_characters(player_state(), map()) -> term().
+-spec list_characters(State, PlayerMap) -> Return
+    when State :: player_state(),
+         Email :: player_email(),
+         Username :: player_name(),
+         PlayerMap :: #{email := Email, username := Username},
+         Return :: ok.
 list_characters(State, #{email := _, username := Username} = Request) ->
     logger:info("[~p] Querying ~p's characters...~n", [?MODULE, Username]),
     Conn = State#player_state.connection,
     Reply = character:player_characters(Request, Conn),
     logger:info("[~p] Characters: ~p~n", [?MODULE, Reply]),
-    State#player_state.client_pid ! Reply.
+    State#player_state.client_pid ! Reply,
+    ok.
 
--spec joining_map(player_state(), map()) -> ok.
+-spec joining_map(State, Map) -> Return
+    when State :: player_state(),
+         Name :: player_name(),
+         MapName :: string(),
+         Map :: #{name := Name, map_name := MapName},
+         Reason :: string(),
+         Return :: ok | {error, Reason}.
 joining_map(State, #{name := Name, map_name := MapName} = Request) ->
     Pid = State#player_state.client_pid,
     Connection = State#player_state.connection,
     case character:activate(Request, Connection) of
         ok ->
-            logger:info("[~p] Retriving ~p's updated info...", [?MODULE, Name]),
+            logger:info("[~p] Retrieving ~p's updated info...", [?MODULE, Name]),
             Result =
                 do([error_m
                     || Character <- character:player_character(Request, Connection),
                        Map <- map:get_map(MapName, Connection),
-                       logger:info("Retriving ~p's map...", [MapName]),
+                       logger:info("Retrieving ~p's map...", [MapName]),
                        return(#{character => Character, map => Map})]),
-            Pid ! Result;
+            Pid ! Result,
+            ok;
         {error, Message} ->
             logger:error("Failed to Join Map: ~p~n", [Message]),
-            Pid ! {error, "Could not join map"}
-    end,
-    ok.
+            Pid ! {error, "Could not join map"},
+            {error, Message}
+    end.
 
 atom_to_upperstring(Atom) ->
     string:uppercase(atom_to_list(Atom)).
@@ -243,7 +261,7 @@ update(State, CharacterMap) ->
             Pid ! {error, Message}
     end.
 
--spec exit_map(player_state()) -> term() | no_return().
+-spec exit_map(player_state()) -> ok | {error, term()}.
 exit_map(State) ->
     Pid = State#player_state.client_pid,
     Name = State#player_state.data#player_data.character_name,
@@ -251,13 +269,17 @@ exit_map(State) ->
     Username = State#player_state.data#player_data.username,
     case character:deactivate(Name, Email, Username, State#player_state.connection) of
         ok ->
-            Pid ! ok;
+            Pid ! ok,
+            ok;
         {error, Message} ->
             logger:error("[~p] Failed to ExitMap: ~p~n", [?MODULE, Message]),
-            exit(2)
+            Pid ! {error, Message},
+            {error, Message}
     end.
 
--spec logout(player_state()) -> no_return().
+-spec logout(State) -> Exit
+    when State :: player_state(),
+         Exit :: no_return().
 logout(State) ->
     Pid = State#player_state.client_pid,
     Name = State#player_state.data#player_data.character_name,
@@ -266,10 +288,10 @@ logout(State) ->
     Connection = State#player_state.connection,
     case character:deactivate(Name, Email, Username, Connection) of
         ok ->
-            storage_mnesia:logout(State#player_state.player_id),
+            cache:logout(State#player_state.player_id),
             Pid ! ok,
-            exit(normal);
+            ok;
         {error, Message} ->
             Pid ! {error, Message},
-            exit(2)
+            ok
     end.

--- a/server/include/player_fsm_state.hrl
+++ b/server/include/player_fsm_state.hrl
@@ -1,0 +1,1 @@
+-type player_fsm_state() :: logged_in | in_game | logged_out.

--- a/server/rebar.config
+++ b/server/rebar.config
@@ -50,7 +50,7 @@
         {lib_database, permanent},
         {lib_map, permanent},
         world,
-        storage_mnesia,
+        cache,
         auth,
         player,
         sasl
@@ -95,7 +95,7 @@
         {lib_database, permanent},
         {lib_map, permanent},
         world,
-        storage_mnesia,
+        cache,
         auth,
         player
     ]}


### PR DESCRIPTION
- Closes #87. Now each Player has a state machine instead of a `gen_server`.
- Renames `storage_mnesia` to `cache`